### PR TITLE
linter launches even when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ any aliased return types it finds.  I'm tempted to write a dumb script that
 uses the `tags` file to build a cross refrence database.
 
 
-#### `g:nvimdev_auto_lint` (default `0`)
+#### `g:nvimdev_auto_lint` (default `1`)
 
-Automatically run `:Neomake` to lint sources after writing buffers.  Disabled
+Adds nvim linter to `g:neomake_c_enabled_makers`.
+
+#### `g:nvimdev_autorun_neomake` (default `0`)
+
+Automatically run `:Neomake` after writing buffers.  Disabled
 by default since cool people would have this already setup.
 
 #### `g:nvimdev_build_readonly` (default `1`)

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -110,7 +110,9 @@ function! nvimdev#init(path) abort
 
   let g:neomake_c_lint_maker = linter
 
-  call add(c_makers, 'lint')
+  if get(g:, 'nvimdev_auto_lint', 1)
+	call add(c_makers, 'lint')
+  endif
   let g:neomake_c_enabled_makers = c_makers
 
   let linter = neomake#makers#ft#lua#luacheck()
@@ -145,7 +147,7 @@ function! nvimdev#init(path) abort
   augroup nvimdev
     autocmd!
     autocmd BufRead,BufNewFile *.h set filetype=c
-    if get(g:, 'nvimdev_auto_lint', 1)
+    if get(g:, 'nvimdev_autorun_neomake', 0)
       autocmd BufWritePost *.c,*.h,*.vim Neomake
     endif
     if get(g:, 'nvimdev_auto_ctags', 1) || get(g:, 'nvimdev_auto_cscope', 0)


### PR DESCRIPTION
nvimdev currently adds the nvim linter in all cases, disabling it just prevents
the autocommand registration. 
But neomake users would tend to have their own autocommand already in which case linter ran even when disabled, e.g., in my init.vim I have `autocmd! BufWritePost * Neomake` so even with `let g:nvimdev_auto_lint=0, linter would still run.

Problem with my approach is that you the user needs to already have an autocmd BufWritePost. 
Maybe I could keep the `autocmd BufWritePost *.c,*.h,*.vim Neomake`but in my case it would run twice for instance ? 