### PR TITLE
make linter also work if not in project root

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -85,7 +85,7 @@ function! nvimdev#init(path) abort
         \ }
 
   function linter.fn(jobinfo) abort
-    let bufname = expand('%')
+    let bufname = substitute(expand('%:p'), s:path . "/" , "", "")
     let errorfile = printf('%s/%s.json', s:errors_root, bufname)
     let maker = copy(self)
     let maker.args = []


### PR DESCRIPTION
The linter currently doesn't work if pwd is not the project root.