### PR TITLE
use :silent in case of 'cscopeverbose'

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -129,7 +129,7 @@ function! nvimdev#init(path) abort
     let &cscopeprg = s:cscope_exe
     let cscope_db = printf('%s/cscope.out', s:path)
     if filereadable(cscope_db)
-      execute 'cscope add' cscope_db
+      execute 'silent cscope add' cscope_db
     endif
   endif
 
@@ -323,7 +323,7 @@ function! s:build_db_job(job, data, event) dict abort
     elseif self.db == 'cscope'
       let cscope_db = printf('%s/cscope.out', s:path)
       if filereadable(cscope_db)
-        execute 'cscope add' cscope_db
+        execute 'silent cscope add' cscope_db
       endif
     endif
   endif


### PR DESCRIPTION
since https://github.com/neovim/neovim/pull/7888 Nvim enables
cscopeverbose by default.  And even before that, users may have set this
option for feedback at the : prompt.