### PR TITLE
Use g:python3_host_prog

### DIFF
--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -153,14 +153,15 @@ endfunction
 
 
 function! nvimdev#update_clint_errors() abort
-  if !executable('python3')
+  let interpreter=get(g:,'python3_host_prog','python3')
+  if !executable(interpreter)
     echohl WarningMsg
     echo '[nvimdev] Python 3 is required to download lint errors'
     echohl None
     return
   endif
 
-  let cmd = ['python3',
+  let cmd = [interpreter,
         \ s:plugin . '/scripts/download_errors.py',
         \ s:errors_root]
   let opts = {


### PR DESCRIPTION
I can't use nvimdev.nvim on nixos because python3 is not in PATH; nixos tries to make everything as explicit as possible and thus sets g:python3_host_prog instead. 
Now I was not sure if neovim sets g:python3_host_prog when it is undefined so this patch might break the use for those with python in PATH. I can fix it to check for both if that's the case.