### PR TITLE
Remove support for nvimdev_autorun_neomake

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,6 @@ uses the `tags` file to build a cross refrence database.
 
 Adds nvim linter to `g:neomake_c_enabled_makers`.
 
-#### `g:nvimdev_autorun_neomake` (default `0`)
-
-Automatically run `:Neomake` after writing buffers.  Disabled
-by default since cool people would have this already setup.
-
 #### `g:nvimdev_build_readonly` (default `1`)
 
 Set files loaded from `build/` or `.deps/` as readonly.

--- a/autoload/nvimdev.vim
+++ b/autoload/nvimdev.vim
@@ -136,9 +136,6 @@ function! nvimdev#init(path) abort
   augroup nvimdev
     autocmd!
     autocmd BufRead,BufNewFile *.h set filetype=c
-    if get(g:, 'nvimdev_autorun_neomake', 0)
-      autocmd BufWritePost *.c,*.h,*.vim Neomake
-    endif
     if get(g:, 'nvimdev_auto_ctags', 1) || get(g:, 'nvimdev_auto_cscope', 0)
       autocmd BufWritePost *.c,*.h,*.lua call s:build_db()
     endif


### PR DESCRIPTION
This was disabled by default already, and should not get managed by a
3rd-party plugin.